### PR TITLE
Externalised data for the navigation

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -7,7 +7,6 @@ import SubscribeMessage from '@economist/component-subscribe-message';
 import React from 'react';
 // Get data.
 import context from '@economist/component-sections-card/context';
-const subscriptionPage = 'https://subscriptions.economist.com/';
 /* eslint-disable id-match */
 // Force media links to use icon as background.
 context.media.forEach((mediaLink) => {
@@ -18,11 +17,24 @@ context.media.forEach((mediaLink) => {
   };
   return mediaLink;
 });
-
+const sharedMenu = {
+  topic: {
+    title: 'Topics',
+    href: '/sections',
+  },
+  more: {
+    title: 'More',
+    href: '/digital',
+  },
+  subscribe: {
+    title: 'Subscribe',
+    href: 'https://subscriptions.economist.com/',
+  },
+};
 const accordionContext = [
   {
-    title: 'Sections',
-    href: '/sections',
+    title: sharedMenu.topic.title,
+    href: sharedMenu.topic.href,
     children: context.sections,
   },
   {
@@ -36,12 +48,12 @@ const accordionContext = [
     href: '/printedition',
   },
   {
-    title: 'Products',
-    href: '/digital',
+    title: sharedMenu.more.title,
+    href: sharedMenu.more.href,
   },
   {
-    title: 'Subscribe',
-    href: subscriptionPage,
+    title: sharedMenu.subscribe.title,
+    href: sharedMenu.subscribe.href,
     target: '_blank',
     unstyled: false,
     i13nModel: {
@@ -50,7 +62,6 @@ const accordionContext = [
     },
   },
 ];
-
 export default (
   <div>
     <div>
@@ -59,7 +70,7 @@ export default (
           autohide={false}
           sectionsCardData={context}
           accordionData={accordionContext}
-          subscriptionPage={subscriptionPage}
+          sharedMenu={sharedMenu}
         >
           <SubscribeMessage counter="1/3"/>
         </Navigation>
@@ -79,12 +90,12 @@ export default (
     </div>
     <div>
       <Navigation className="navigation navigation--registered navigation--sticked"
-          svgUri="assets/icons.svg"
-          userLoggedIn={true}
-          autohide={false}
-          sectionsCardData={context}
-          accordionData={accordionContext}
-          subscriptionPage={subscriptionPage}
+        svgUri="assets/icons.svg"
+        userLoggedIn
+        autohide={false}
+        sectionsCardData={context}
+        accordionData={accordionContext}
+        sharedMenu={sharedMenu}
       />
     </div>
   </div>

--- a/example.es6
+++ b/example.es6
@@ -5,6 +5,51 @@ if (typeof document === 'object') {
 import Navigation from './index';
 import SubscribeMessage from '@economist/component-subscribe-message';
 import React from 'react';
+// Get data.
+import context from '@economist/component-sections-card/context';
+const subscriptionPage = 'https://subscriptions.economist.com/';
+/* eslint-disable id-match */
+// Force media links to use icon as background.
+context.media.forEach((mediaLink) => {
+  mediaLink.icon = {
+    useBackground: true,
+    color: 'chicago',
+    icon: mediaLink.meta,
+  };
+  return mediaLink;
+});
+
+const accordionContext = [
+  {
+    title: 'Sections',
+    href: '/sections',
+    children: context.sections,
+  },
+  {
+    title: 'Blogs',
+    href: '/blogs',
+    children: context.blogs,
+  },
+  ...context.media,
+  {
+    title: 'Print Edition',
+    href: '/printedition',
+  },
+  {
+    title: 'Products',
+    href: '/digital',
+  },
+  {
+    title: 'Subscribe',
+    href: subscriptionPage,
+    target: '_blank',
+    unstyled: false,
+    i13nModel: {
+      action: 'click',
+      element: 'subscribe',
+    },
+  },
+];
 
 export default (
   <div>
@@ -12,6 +57,9 @@ export default (
         <Navigation className="navigation navigation--registered navigation--sticked"
           svgUri="assets/icons.svg"
           autohide={false}
+          sectionsCardData={context}
+          accordionData={accordionContext}
+          subscriptionPage={subscriptionPage}
         >
           <SubscribeMessage counter="1/3"/>
         </Navigation>
@@ -33,7 +81,11 @@ export default (
       <Navigation className="navigation navigation--registered navigation--sticked"
           svgUri="assets/icons.svg"
           userLoggedIn={true}
-          autohide={false} />
+          autohide={false}
+          sectionsCardData={context}
+          accordionData={accordionContext}
+          subscriptionPage={subscriptionPage}
+      />
     </div>
   </div>
 );

--- a/index.es6
+++ b/index.es6
@@ -6,51 +6,8 @@ import Button from '@economist/component-link-button';
 import GoogleSearch from '@economist/component-google-search';
 import Balloon from '@economist/component-balloon';
 import SectionsCard from '@economist/component-sections-card';
-import context from '@economist/component-sections-card/context';
 import Accordion from '@economist/component-accordion';
-const subscriptionPage = 'https://subscriptions.economist.com/';
-/* eslint-disable id-match */
-// Force media links to use icon as background.
-context.media.forEach((mediaLink) => {
-  mediaLink.icon = {
-    useBackground: true,
-    color: 'chicago',
-    icon: mediaLink.meta,
-  };
-  return mediaLink;
-});
 
-const accordionContext = [
-  {
-    title: 'Sections',
-    href: '/sections',
-    children: context.sections,
-  },
-  {
-    title: 'Blogs',
-    href: '/blogs',
-    children: context.blogs,
-  },
-  ...context.media,
-  {
-    title: 'Print Edition',
-    href: '/printedition',
-  },
-  {
-    title: 'Products',
-    href: '/digital',
-  },
-  {
-    title: 'Subscribe',
-    href: subscriptionPage,
-    target: '_blank',
-    unstyled: false,
-    i13nModel: {
-      action: 'click',
-      element: 'subscribe',
-    },
-  },
-];
 export default class Navigation extends React.Component {
 
   static get propTypes() {
@@ -65,6 +22,9 @@ export default class Navigation extends React.Component {
       svgUri: React.PropTypes.string,
       userLoggedIn: React.PropTypes.bool,
       currentUrl: React.PropTypes.string,
+      subscriptionPage: React.PropTypes.string,
+      sectionsCardData: React.PropTypes.object.isRequired,
+      accordionData: React.PropTypes.array.isRequired,
     };
   }
 
@@ -125,7 +85,7 @@ export default class Navigation extends React.Component {
       <Icon icon="close" size="28px" color="white" />
     </a>);
     const menuSectionsTrigger = (<a href="/Sections" className="navigation__sections-link">
-      Sections
+      Topics
     </a>);
     const primaryNavigation = (
       <div className="navigation__primary" key="primary-navigation">
@@ -138,24 +98,25 @@ export default class Navigation extends React.Component {
             className="navigation__main-navigation-link navigation__mobile-accordion"
             trigger={menuAccordionTrigger}
           >
-            <Accordion list={accordionContext}/>
+            <Accordion list={this.props.accordionData}/>
           </Balloon>
           <Balloon
             className="navigation__main-navigation-link navigation__main-sections-card"
             showOnHover
             trigger={menuSectionsTrigger}
-          ><div>
-              <SectionsCard data={context} />
+          >
+            <div>
+              <SectionsCard data={this.props.sectionsCardData}/>
             </div>
           </Balloon>
           <a href="/printedition" className="navigation__main-navigation-link">
             Print edition
           </a>
           <a href="/digital" className="navigation__main-navigation-link">
-            Products
+            More
           </a>
           <div className="navigation__primary-expander"></div>
-          <Button href={subscriptionPage}
+          <Button href={this.props.subscriptionPage}
             className="navigation__main-navigation-link navigation__main-navigation-link-subscribe"
             target="_blank"
             i13nModel={{

--- a/index.es6
+++ b/index.es6
@@ -22,7 +22,7 @@ export default class Navigation extends React.Component {
       svgUri: React.PropTypes.string,
       userLoggedIn: React.PropTypes.bool,
       currentUrl: React.PropTypes.string,
-      subscriptionPage: React.PropTypes.string,
+      sharedMenu: React.PropTypes.object.isRequired,
       sectionsCardData: React.PropTypes.object.isRequired,
       accordionData: React.PropTypes.array.isRequired,
     };
@@ -84,8 +84,8 @@ export default class Navigation extends React.Component {
       <Icon icon="hamburger" size="28px" color="white" />
       <Icon icon="close" size="28px" color="white" />
     </a>);
-    const menuSectionsTrigger = (<a href="/Sections" className="navigation__sections-link">
-      Topics
+    const menuSectionsTrigger = (<a href={this.props.sharedMenu.topic.href} className="navigation__sections-link">
+      {this.props.sharedMenu.topic.title}
     </a>);
     const primaryNavigation = (
       <div className="navigation__primary" key="primary-navigation">
@@ -112,11 +112,11 @@ export default class Navigation extends React.Component {
           <a href="/printedition" className="navigation__main-navigation-link">
             Print edition
           </a>
-          <a href="/digital" className="navigation__main-navigation-link">
-            More
+          <a href={this.props.sharedMenu.more.href} className="navigation__main-navigation-link">
+            {this.props.sharedMenu.more.title}
           </a>
           <div className="navigation__primary-expander"></div>
-          <Button href={this.props.subscriptionPage}
+          <Button href={this.props.sharedMenu.subscribe.href}
             className="navigation__main-navigation-link navigation__main-navigation-link-subscribe"
             target="_blank"
             i13nModel={{
@@ -125,7 +125,7 @@ export default class Navigation extends React.Component {
             }}
             unstyled
           >
-            Subscribe
+            {this.props.sharedMenu.subscribe.title}
           </Button>
           <div className="navigation__user-menu">
             {this.renderLoginLogout()}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-navigation",
-  "version": "1.10.1",
+  "version": "2.0.0",
   "description": "A navigation masthead",
   "author": "The Economist (http://economist.com)",
   "license": "LicenseRef-LICENSE",

--- a/test/index.es6
+++ b/test/index.es6
@@ -4,7 +4,6 @@ import TestUtils from 'react-addons-test-utils';
 import links from '../links';
 // Get data.
 import context from '@economist/component-sections-card/context';
-const subscriptionPage = 'https://subscriptions.economist.com/';
 /* eslint-disable id-match */
 // Force media links to use icon as background.
 context.media.forEach((mediaLink) => {
@@ -16,10 +15,24 @@ context.media.forEach((mediaLink) => {
   return mediaLink;
 });
 
+const sharedMenu = {
+  topic: {
+    title: 'Topics',
+    href: '/sections',
+  },
+  more: {
+    title: 'More',
+    href: '/digital',
+  },
+  subscribe: {
+    title: 'Subscribe',
+    href: 'https://subscriptions.economist.com/',
+  },
+};
 const accordionContext = [
   {
-    title: 'Sections',
-    href: '/sections',
+    title: sharedMenu.topic.title,
+    href: sharedMenu.topic.href,
     children: context.sections,
   },
   {
@@ -33,12 +46,12 @@ const accordionContext = [
     href: '/printedition',
   },
   {
-    title: 'Products',
-    href: '/digital',
+    title: sharedMenu.more.title,
+    href: sharedMenu.more.href,
   },
   {
-    title: 'Subscribe',
-    href: subscriptionPage,
+    title: sharedMenu.subscribe.title,
+    href: sharedMenu.subscribe.href,
     target: '_blank',
     unstyled: false,
     i13nModel: {
@@ -47,7 +60,6 @@ const accordionContext = [
     },
   },
 ];
-
 const registered = [ links.subscribe, links.myeconomist, links.logout ];
 describe(`A navigation`, () => {
   describe(`it's a React component`, () => {
@@ -61,7 +73,7 @@ describe(`A navigation`, () => {
           links={registered}
           sectionsCardData={context}
           accordionData={accordionContext}
-          subscriptionPage={subscriptionPage}
+          sharedMenu={sharedMenu}
         />).should.equal(true);
     });
   });
@@ -71,7 +83,7 @@ describe(`A navigation`, () => {
         currentUrl: '/foo/bar',
         sectionsCardData: context,
         accordionData: accordionContext,
-        subscriptionPage,
+        sharedMenu,
       });
       const loginLogoutButton = TestUtils.renderIntoDocument(
         instance.renderLoginLogout()
@@ -80,7 +92,7 @@ describe(`A navigation`, () => {
         loginLogoutButton,
         'navigation__user-menu-link'
       );
-      linkButton.href.should.contain('/user/login?destination=%2Ffoo%2Fbar')
+      linkButton.href.should.contain('/user/login?destination=%2Ffoo%2Fbar');
     });
     it('When the user is logged in it\'s a link to /logout?destination={this.props.currentUrl}', () => {
       const instance = new Navigation({
@@ -88,10 +100,10 @@ describe(`A navigation`, () => {
         userLoggedIn: true,
         sectionsCardData: context,
         accordionData: accordionContext,
-        subscriptionPage,
+        sharedMenu,
       });
       instance.renderLoginLogout()
-        .props.href.should.equal('/logout?destination=%2Ffoo%2Fbar')
+        .props.href.should.equal('/logout?destination=%2Ffoo%2Fbar');
     });
   });
 });

--- a/test/index.es6
+++ b/test/index.es6
@@ -2,6 +2,51 @@ import Navigation from '../index.es6';
 import React from 'react';
 import TestUtils from 'react-addons-test-utils';
 import links from '../links';
+// Get data.
+import context from '@economist/component-sections-card/context';
+const subscriptionPage = 'https://subscriptions.economist.com/';
+/* eslint-disable id-match */
+// Force media links to use icon as background.
+context.media.forEach((mediaLink) => {
+  mediaLink.icon = {
+    useBackground: true,
+    color: 'chicago',
+    icon: mediaLink.meta,
+  };
+  return mediaLink;
+});
+
+const accordionContext = [
+  {
+    title: 'Sections',
+    href: '/sections',
+    children: context.sections,
+  },
+  {
+    title: 'Blogs',
+    href: '/blogs',
+    children: context.blogs,
+  },
+  ...context.media,
+  {
+    title: 'Print Edition',
+    href: '/printedition',
+  },
+  {
+    title: 'Products',
+    href: '/digital',
+  },
+  {
+    title: 'Subscribe',
+    href: subscriptionPage,
+    target: '_blank',
+    unstyled: false,
+    i13nModel: {
+      action: 'click',
+      element: 'subscribe',
+    },
+  },
+];
 
 const registered = [ links.subscribe, links.myeconomist, links.logout ];
 describe(`A navigation`, () => {
@@ -14,13 +59,19 @@ describe(`A navigation`, () => {
         <Navigation
           className="navigation navigation--registered navigation--sticked"
           links={registered}
+          sectionsCardData={context}
+          accordionData={accordionContext}
+          subscriptionPage={subscriptionPage}
         />).should.equal(true);
     });
   });
   describe('login/logout button', () => {
     it('is a link to /user/login?destination={this.props.currentUrl}', () => {
       const instance = new Navigation({
-        currentUrl: '/foo/bar'
+        currentUrl: '/foo/bar',
+        sectionsCardData: context,
+        accordionData: accordionContext,
+        subscriptionPage,
       });
       const loginLogoutButton = TestUtils.renderIntoDocument(
         instance.renderLoginLogout()
@@ -35,6 +86,9 @@ describe(`A navigation`, () => {
       const instance = new Navigation({
         currentUrl: '/foo/bar',
         userLoggedIn: true,
+        sectionsCardData: context,
+        accordionData: accordionContext,
+        subscriptionPage,
       });
       instance.renderLoginLogout()
         .props.href.should.equal('/logout?destination=%2Ffoo%2Fbar')


### PR DESCRIPTION
The basic requrest for these PR was to update the label of the menus:

'Sections' become 'Topics'
'Products' become 'More'

Then I thought it was I good idea moving the data outside of the component (I will add a static version of @economist/component-sections-card/context inside fe-blogs) and to prevent error due to the 2 different menus I centralised some information shared betwen the accordion, the sections card and the top menu.

So next step will be move the data and the relative massaging on fe-blogs.