### PR TITLE
[DO NOT MERGE] component-navigation: Refactored google-search and background icons.

### DIFF
--- a/index.css
+++ b/index.css
@@ -10,6 +10,9 @@
 @import "@economist/component-icon/backgrounds/headset.css";
 @import "@economist/component-icon/backgrounds/video.css";
 @import "@economist/component-icon/backgrounds/film.css";
+@import "@economist/component-icon/backgrounds/magnifier.css";
+@import "@economist/component-icon/backgrounds/user.css";
+@import "@economist/component-icon/backgrounds/close.css";
 
 .navigation {
   font-size: 1rem;
@@ -21,7 +24,6 @@
 .navigation .navigation__main-navigation-link > a {
   text-decoration: none;
   height: var(--navigation__default-height);
-  padding-top: var(--navigation__link-top-padding);
   box-sizing: border-box;
 }
 
@@ -98,10 +100,8 @@
 
 @media (--navigation-mobile-up){
   .navigation__sections-link:hover,
-  .navigation__main-navigation-link:hover,
-  .navigation__user-menu:hover .link-button__text,
-  .navigation__search:hover .search__search-label {
-    color: var(--navigation__default-hover-color, var(--color-london));
+  .navigation__link:hover {
+    filter: grayscale(100%) brightness(5) brightness(80%);
   }
 
   .navigation__user-menu:hover use,

--- a/index.es6
+++ b/index.es6
@@ -7,6 +7,7 @@ import GoogleSearch from '@economist/component-google-search';
 import Balloon from '@economist/component-balloon';
 import SectionsCard from '@economist/component-sections-card';
 import Accordion from '@economist/component-accordion';
+import classnames from 'classnames';
 
 export default class Navigation extends React.Component {
 
@@ -31,11 +32,16 @@ export default class Navigation extends React.Component {
     };
   }
 
-  static get defaultProps() {
-    return {
-      autohide: true,
-      penName: 'guest-olejses',
-      logoutDestination: '',
+  static defaultProps = {
+    autohide: true,
+    penName: 'guest-olejses',
+    logoutDestination: '',
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      searching: false,
     };
   }
 
@@ -50,7 +56,7 @@ export default class Navigation extends React.Component {
       <Button
         href={buttonUrl}
         className={`navigation__user-menu-link navigation__user-menu-link--${buttonClassSuffix}`}
-        icon={{ icon: 'user', size: '28px' }}
+        icon={{ icon: 'user', color: 'thimphu', useBackground: true }}
         unstyled
       >{buttonText}</Button>
     );
@@ -168,21 +174,80 @@ export default class Navigation extends React.Component {
     );
   }
 
+  renderSearch(searching) {
+    if (searching) {
+      return (
+        <div className="navigation__search--open">
+          <div className="navigation__search-magnifier">
+            <Icon icon="magnifier" size="28px" />
+          </div>
+          <GoogleSearch />
+          <div className="navigation__search-close-button-wrapper">
+            <Button
+              unstyled
+              className="navigation__link navigation__search-close-button"
+              icon={{ icon: 'close', color: 'thimphu', useBackground: true }}
+              onClick={this.closeSearchBar}
+            />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="navigation__search--closed">
+        <div className="navigation__show-field-group">
+          <Button
+            unstyled
+            icon={{ icon: 'magnifier', size: '28px' }}
+            className="navigation__link navigation__collapsed-magnifier"
+            href="http://www.economist.com/search/"
+            onClick={this.openSearchBar}
+          />
+          <Button
+            unstyled
+            icon={{ icon: 'magnifier', color: 'thimphu', useBackground: true }}
+            className="navigation__link navigation__search-open-button"
+            href="http://www.economist.com/search/"
+            onClick={this.openSearchBar}
+          >
+            Search
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  closeSearchBar = () => {
+    this.setState({ searching: false });
+  }
+
+  openSearchBar = (event) => {
+    event.stopPropagation();
+    event.preventDefault();
+    this.setState({ searching: true });
+    return false;
+  }
+
   render() {
+    const { searching } = this.state;
     const svgUri = { uri: this.props.svgUri } || {};
-    const menuAccordionTrigger = (<a href="/Sections" className="navigation__sections-link navigation--tappable-icon">
-      <Icon icon="hamburger" size="28px" color="white" />
-      <Icon icon="close" size="28px" color="white" />
-    </a>);
-    const menuSectionsTrigger = (<a href={this.props.sharedMenu.topic.href} className="navigation__sections-link">
-      {this.props.sharedMenu.topic.title}
-    </a>);
-    const primaryNavigation = (
+    const menuAccordionTrigger = (
+      <a href="/Sections" className="navigation__sections-link navigation--tappable-icon">
+        <Icon icon="hamburger" size="28px" color="white" />
+        <Icon icon="close" size="28px" color="white" />
+      </a>
+    );
+    const menuSectionsTrigger = (
+      <a href={this.props.sharedMenu.topic.href} className="navigation__sections-link">
+        {this.props.sharedMenu.topic.title}
+      </a>
+    );
+    const children = [ (
       <div className="navigation__primary" key="primary-navigation">
         <div className="navigation__primary-inner">
           <a href="http://www.economist.com" className="navigation__link-logo">
             <Icon icon="economist" size="64px" {...svgUri}/>
-            <div className="navigation__link-empty-logo"></div>
+            <div className="navigation__link-empty-logo" />
           </a>
           <Balloon
             className="navigation__main-navigation-link navigation__mobile-accordion"
@@ -199,15 +264,15 @@ export default class Navigation extends React.Component {
               <SectionsCard data={this.props.sectionsCardData}/>
             </div>
           </Balloon>
-          <a href="/printedition" className="navigation__main-navigation-link">
+          <a href="/printedition" className="navigation__main-navigation-link navigation__link">
             Print edition
           </a>
-          <a href={this.props.sharedMenu.more.href} className="navigation__main-navigation-link">
+          <a href={this.props.sharedMenu.more.href} className="navigation__main-navigation-link navigation__link">
             {this.props.sharedMenu.more.title}
           </a>
-          <div className="navigation__primary-expander"></div>
+          <div className="navigation__primary-expander" />
           <Button href={this.props.sharedMenu.subscribe.href}
-            className="navigation__main-navigation-link navigation__main-navigation-link-subscribe"
+            className="navigation__main-navigation-link navigation__link navigation__main-navigation-link-subscribe"
             target="_blank"
             i13nModel={{
               action: 'click',
@@ -221,27 +286,29 @@ export default class Navigation extends React.Component {
             {this.renderLoginLogout()}
           </div>
           <div className="navigation__search">
-            <GoogleSearch/>
+            {this.renderSearch(searching)}
           </div>
         </div>
       </div>
-    );
-    const children = [ primaryNavigation ];
-    let autohide = '';
-    let bottomBar = '';
+    ) ];
+
     if (this.props.autohide) {
-      autohide = ' navigation--autohide';
-      bottomBar = (<AutoHide className="navigation__secondary" key="secondary-autohide">
+      children.push(
+        <AutoHide className="navigation__secondary" key="secondary-autohide">
           {this.props.children}
-        </AutoHide>);
+        </AutoHide>
+      );
     } else {
-      bottomBar = (<div className="navigation__secondary" key="secondary">
+      children.push(
+        <div className="navigation__secondary" key="secondary">
           {this.props.children}
-        </div>);
+        </div>
+      );
     }
-    children.push(bottomBar);
     return (
-      <StickyPosition className={`${this.props.className} ${autohide}`}>
+      <StickyPosition
+        className={classnames(this.props.className, { 'navigation--autohide': this.props.autohide })}
+      >
          {children}
       </StickyPosition>
     );

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "compact": false
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
+    "plugins": [
+      "babel"
+    ],
     "extends": [
       "strict",
       "strict-react"
@@ -139,6 +143,7 @@
     "@economist/component-link-button": "^2.0.0",
     "@economist/component-sections-card": "^3.0.0",
     "@economist/component-subscribe-message": "^1.2.0",
+    "classnames": "^2.2.3",
     "react-sticky-position": "^2.0.0",
     "svg4everybody": "^2.0.0"
   },
@@ -149,6 +154,7 @@
     "@economist/component-typography": "^3.1.1",
     "babel": "^5.8.23",
     "babel-core": "^5.8.35",
+    "babel-eslint": "^5.0.0",
     "babelify": "^6.3.0",
     "browser-sync": "^2.8.2",
     "browserify": "^11.0.1",
@@ -159,6 +165,7 @@
     "eslint": "^1.3.1",
     "eslint-config-strict": "^5.0.0",
     "eslint-config-strict-react": "^2.0.0",
+    "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-react": "^3.3.1",
     "karma": "^0.13.10",

--- a/search.css
+++ b/search.css
@@ -7,46 +7,92 @@
   --search__search-label__font-size: var(--navigation-text-size);
 }
 
-.navigation__primary-inner {
-  display: flex;
-}
-
-.navigation__link-search {
-  padding: 5px var(--grid-gutter-s);
-  vertical-align: middle;
-  width: 1em;
-}
-
-.navigation__link-search use,
-.navigation__link-search svg {
-  fill: var(--color-thimphu);
-}
-
 .navigation__search {
   flex: 0 1 auto;
-  padding: 0 var(--navigation__default-menus-padding, var(--main-navigation-link-padding));
+  padding: 0 32px 0 var(--navigation__default-menus-padding, var(--main-navigation-link-padding));
 }
 
-.navigation .search {
+.navigation__search--open,
+.navigation__search--closed {
+  border-collapse: collapse;
+  color: var(--search__color, var(--color-thimphu));
   display: table;
+  font-size: 1em;
   height: var(--navigation__height, var(--navigation__default-height));
+  left: auto;
   right: 10px;
 }
 
-.navigation .search .Icon {
-  width: var(--navigation-icon-size);
+.navigation__search .error--message {
+  color: var(--color-economist);
 }
 
-.navigation .search .Icon-magnifier {
-  margin-right: 4px;
+.navigation__search-magnifier {
+  border-top: 1px solid var(--search__border-top-color, var(--color-berlin));
+  min-width: 50px;
+  text-align: center;
+  vertical-align: middle;
+  display: table-cell;
 }
 
-.navigation .search__search-label {
-  padding-top: 4px;
+.navigation__collapsed-magnifier {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+  width: 64px;
+  min-width: 50px;
+}
+
+.navigation__collapsed-magnifier use,
+.navigation__collapsed-magnifier svg {
+  fill: var(--color-thimphu);
+}
+
+.navigation__search--open {
+  background: var(--search--open__background, var(--color-thimphu));
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
+.navigation__show-field-group {
+  display: table-row;
+}
+
+.navigation__search-open-button.icon--magnifier-thimphu {
+  background-position: left center;
+  background-size: 24px 24px;
+  color: var(--search__color, var(--color-thimphu));
+  display: table-cell;
+  font-size: var(--search__search-label__font-size, var(--text-size-step--1));
+  height: var(--search__search-label__height, var(--text-size-step--1));
+  min-width: 50px;
+  padding-left: 28px;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.navigation__search-close-button-wrapper {
+  background-color: var(--search-close__background, var(--color-kiev));
+  height: var(--search__close-button-height, 64px);
+  width: var(--search__close-button-height, 64px);
+  display: flex;
+  min-width: 50px;
+  box-sizing: border-box;
+}
+
+.navigation__search-close-button.icon--close-thimphu {
+  width: 100%;
+  height: 100%;
+  background-size: 24px 24px;
+  background-position: center center;
 }
 
 @media (--navigation-mobile-down){
-  .navigation__search .search__magnifier {
+  .navigation__search--open .navigation__search-open-button {
     height: var(--navigation__height, var(--navigation__default-height));
     width: var(--navigation__height, var(--navigation__default-height));
   }
@@ -56,12 +102,27 @@
   .navigation__search  {
     padding: 0;
   }
-  .navigation__search .search__magnifier {
+  .navigation__search-open-button {
     min-width: 50px;
     text-align: center;
   }
-  .navigation__search .search__search-label {
+
+  .navigation__collapsed-magnifier {
+    display: table-cell;
+  }
+
+  .navigation__show-field-group .navigation__search-open-button {
     display: none;
+  }
+}
+
+@media (--navigation-tablet-up) {
+  .navigation__collapsed-magnifier {
+    display: none;
+  }
+
+  .navigation__show-field-group .navigation__search-open-button {
+    display: table-cell;
   }
 }
 

--- a/settings.css
+++ b/settings.css
@@ -1,6 +1,7 @@
 @import "@economist/component-typography";
 
 @custom-media --navigation-tablet-down (width <= 860px);
+@custom-media --navigation-tablet-up (width >= 860px);
 @custom-media --navigation-mobile-down (width <= 768px);
 @custom-media --navigation-mobile-up (width >= 769px);
 

--- a/user-menu.css
+++ b/user-menu.css
@@ -6,11 +6,13 @@
   font-family: inherit;
   display: flex;
   align-items: stretch;
-  padding: 0;
+  padding: 0 var(--navigation__default-menus-padding, var(--main-navigation-link-padding));
 }
 
-.navigation__user-menu .link-button__group {
-  margin-bottom: 5px;
+.navigation__user-menu .icon--user-thimphu {
+  background-size: 24px 24px;
+  padding-left: 30px;
+  background-position: left center;
 }
 
 .navigation__user-menu-link {
@@ -24,7 +26,6 @@
 .navigation__user-menu-link--login {
   color: var(--navigation-user-menu-color, var(--color-thimphu));
   font-size: var(--navigation-user-menu-font-size, var(--navigation-text-size));
-  padding: 0 var(--navigation__default-menus-padding, var(--main-navigation-link-padding));
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   outline: 0;
 }
@@ -33,16 +34,6 @@
 .navigation__user-menu-link--logout {
   white-space: nowrap;
   height: var(--navigation__default-height);
-}
-
-.navigation__user-menu .Icon,
-.navigation__user-menu .Icon use {
-  fill: var(--navigation-user-icon-color, var(--color-thimphu));
-}
-
-.navigation__user-menu-link--logout .Icon,
-.navigation__user-menu-link--logout .Icon use {
-  fill: var(--navigation-user-menu-color, var(--color-thimphu));
 }
 
 .navigation__user-menu .balloon-content {
@@ -113,11 +104,6 @@
   .navigation__user-menu .balloon-content {
     right: -40px !important;
   }
-}
-
-.navigation__user-menu .Icon {
-  width: var(--navigation-icon-size);
-  margin-right: 5px;
 }
 
 .navigation__user-menu-the-economist-name {


### PR DESCRIPTION
Please wait for the other PRs to merged, so I can update the dependencies in `package.json`.

This commit brings some major and breaking changes:
- The controller (open and close) for the google-search component, is extracted into this component
- The icons for the login and search button are now background images
- All of the items in the navigation bar are now correctly vertically aligned at the middle

Depends on https://github.com/economist-components/component-google-search/pull/11
and https://github.com/economist-components/component-icon/pull/28
and https://github.com/economist-components/component-balloon/pull/10

Roadmap: The different links use different css classes and methods to achieve vertical alignment. It would be better to use the same methodology everywhere (flex vs table).