### PR TITLE
fix: update prc & reprovision, which fixes build issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@
 
 ## Usage
 
-Simply import the component for use in your project:
+**This component expects an ES6 environment**, and so if you are using this in an app,
+you should drop in a polyfill library - it has been tested with [babel-polyfill] but
+[core-js] or [es6-shim] may also work.
+
+[babel-polyfill]: https://babeljs.io/docs/usage/polyfill/
+[core-js]: https://www.npmjs.com/package/core-js
+[es6-shim]: https://www.npmjs.com/package/es6-shim
+
+The default export is a React Component, so you can simply import the component and use
+it within some JSX, like so:
 
 ```js
 import Navigation from '@economist/component-navigation';
@@ -12,7 +21,7 @@ import Navigation from '@economist/component-navigation';
 return <Navigation/>;
 ```
 
-For more examples on usage, see [`src/example.es6`]](./src/example.es6).
+For more examples on usage, see [`src/example.es6`](./src/example.es6).
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "@economist/component-navigation",
   "version": "3.0.1",
   "description": "A navigation masthead",
-  "homepage": "http://github.com/economist-components/component-navigation",
+  "homepage": "https://github.com/economist-components/component-navigation",
   "bugs": {
-    "url": "http://github.com/economist-components/component-navigation/issues"
+    "url": "https://github.com/economist-components/component-navigation/issues"
   },
   "license": "MIT",
   "author": "The Economist (http://economist.com)",
@@ -52,7 +52,7 @@
     "doc:js": "browserify $npm_package_config_doc_js_options $npm_package_directories_test/*.js -o $npm_package_directories_site/bundle.js",
     "lint": "npm-run-all --parallel lint:*",
     "lint:css": "stylelint $npm_package_directories_src/*.css",
-    "lint:js": "eslint $npm_package_directories_src",
+    "lint:js": "eslint --ignore-path .gitignore .",
     "prepages": "npm run doc",
     "pages": "git-directory-deploy --directory $npm_package_directories_site --branch gh-pages",
     "provision": "provision-react-component",
@@ -140,10 +140,11 @@
     "@economist/component-palette": "^1.4.4",
     "@economist/component-typography": "^3.1.1",
     "@economist/doc-pack": "^1.0.6",
-    "@economist/provision-react-component": "1.4.0",
+    "@economist/provision-react-component": "^1.4.2",
     "babel": "^5.8.34",
     "babel-core": "^5.8.35",
     "babel-eslint": "^5.0.0",
+    "babel-polyfill": "^6.6.1",
     "babelify": "^6.4.0",
     "browserify": "^13.0.0",
     "chai": "^3.5.0",

--- a/src/example.js
+++ b/src/example.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import Navigation from './';
 import React from 'react';
 import navgiationLinks from '@economist/component-sections-card/context';

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import Navigation from '../src';
 import React from 'react';
 import chai from 'chai';


### PR DESCRIPTION
### DO NOT MERGE BEFORE https://github.com/economist-components/provision-react-component/pull/40

This is a slightly pre-emptive PR. When https://github.com/economist-components/provision-react-component/pull/40 gets merged, this will be the resulting prc update PR for this component, I'm doing it ahead of time to get things moving quickly.

This fixes build issues that we're having with this component. Once this PR has been made the build should pass and we'll have a new version to add to fe-blogs.