### PR TITLE
feat: TEC-578, add 'More' dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,12 +121,12 @@
     ]
   },
   "dependencies": {
-    "@economist/component-accordion": "^4.0.2",
-    "@economist/component-balloon": "^2.0.2",
+    "@economist/component-accordion": "4.1.0",
+    "@economist/component-balloon": "^2.2.0",
     "@economist/component-google-search": "^3.0.0",
-    "@economist/component-icon": "^5.9.1",
+    "@economist/component-icon": "^5.10.0",
     "@economist/component-link-button": "^2.0.0",
-    "@economist/component-sections-card": "^3.0.0",
+    "@economist/component-sections-card": "^3.1.0",
     "babel-runtime": "^6.3.19",
     "classnames": "^2.2.3",
     "lodash.throttle": "^4.0.1",

--- a/src/example.js
+++ b/src/example.js
@@ -1,14 +1,13 @@
 import 'babel-polyfill';
 import Navigation from './';
 import React from 'react';
-import navgiationLinks from '@economist/component-sections-card/context';
+import navigationLinks from '@economist/component-sections-card/lib/context';
 import svgForEverybody from 'svg4everybody';
-/* eslint-disable id-match */
 // Force media links to use icon as background.
 if (typeof document === 'object') {
   svgForEverybody();
 }
-navgiationLinks.media.forEach((mediaLink) => {
+navigationLinks.media.forEach((mediaLink) => {
   mediaLink.icon = {
     useBackground: true,
     color: 'chicago',
@@ -30,21 +29,147 @@ const sharedMenu = {
     href: 'https://subscriptions.economist.com/',
   },
 };
+const moreBalloonData = {
+  sections: [
+    {
+      'title': 'Economist on iPhone',
+      'href': 'https://itunes.apple.com/us/app/economist-global-business/id951457811?ls=1&mt=8',
+      internal: false,
+    },
+    {
+      'title': 'Economist on iPad',
+      'href': 'https://search.itunes.apple.com/WebObjects/MZContentLink.woa/wa/link?path=apps%2ftheeconomist',
+      internal: false,
+    },
+    {
+      'title': 'Espresso',
+      'href': '/digital',
+    },
+    {
+      'title': 'Global Business Review',
+      'href': '/sections/business-finance',
+    },
+    {
+      'title': 'Work in Figures',
+      'href': 'https://worldinfigures.com/',
+    },
+  ],
+  'media': [
+    {
+      'title': 'Apps',
+      'meta': 'apps',
+      'href': '/digital',
+      'internal': false,
+      'icon': {
+        'useBackground': true,
+        'color': 'chicago',
+        'icon': 'apps',
+      },
+    },
+    {
+      'title': 'Audio',
+      'meta': 'headset',
+      'href': '/audio-edition',
+      'internal': false,
+      'icon': {
+        'useBackground': true,
+        'color': 'chicago',
+        'icon': 'headset',
+      },
+    },
+    {
+      'title': 'Video',
+      'meta': 'video',
+      'href': 'http://www.economist.com/multimedia',
+      'internal': false,
+      'icon': {
+        'useBackground': true,
+        'color': 'chicago',
+        'icon': 'video',
+      },
+    },
+    {
+      'title': 'Radio',
+      'meta': 'radio',
+      'href': 'http://radio.economist.com/',
+      'internal': false,
+      'icon': {
+        'useBackground': true,
+        'color': 'chicago',
+        'icon': 'radio',
+      },
+    },
+    {
+      'title': 'Films',
+      'meta': 'film',
+      'href': 'http://films.economist.com/',
+      'internal': false,
+      'icon': {
+        'useBackground': true,
+        'color': 'chicago',
+        'icon': 'film',
+      },
+    },
+  ],
+  'blogs': [
+    {
+      'title': 'Events',
+      'href': '/events-conferences',
+    },
+    {
+      'title': 'Jobs Board',
+      'href': 'http://jobs.economist.com/',
+    },
+    {
+      'title': 'Which MBA',
+      'href': '/whichmba',
+    },
+    {
+      'title': 'Executive Education Navigator',
+      'href': 'https://execed.economist.com/',
+    },
+    {
+      'title': 'GMAT tutor',
+      'href': 'https://gmat.economist.com/',
+    },
+    {
+      'title': 'GRE tutor',
+      'href': 'https://gre.economist.com/',
+    },
+    {
+      'title': 'Learning.ly',
+      'href': 'https://learning.ly',
+      internal: false,
+    },
+    {
+      'title': '1843',
+      'href': '/help/about-us',
+    },
+  ],
+};
 const accordionContext = [
   {
     title: sharedMenu.topic.title,
     href: sharedMenu.topic.href,
-    children: navgiationLinks.sections,
+    children: navigationLinks.sections,
   },
   {
     title: 'Blogs',
     href: '/blogs',
-    children: navgiationLinks.blogs,
+    children: navigationLinks.blogs,
   },
-  ...navgiationLinks.media,
   {
     title: 'Print Edition',
     href: '/printedition',
+  },
+  ...navigationLinks.media,
+  {
+    title: 'Products',
+    children: [
+      ...moreBalloonData.sections,
+      { hr: true }, // eslint-disable-line id-length
+      ...moreBalloonData.blogs,
+    ],
   },
   {
     title: sharedMenu.more.title,
@@ -55,7 +180,7 @@ const accordionContext = [
     href: sharedMenu.subscribe.href,
     target: '_blank',
     unstyled: false,
-    i13nModel: {
+    i13nModel: { // eslint-disable-line id-match
       action: 'click',
       element: 'subscribe',
     },
@@ -66,7 +191,8 @@ export default (
     <div>
         <Navigation className="navigation navigation--registered navigation--sticked"
           svgUri="assets/icons.svg"
-          sectionsCardData={navgiationLinks}
+          sectionsCardData={navigationLinks}
+          moreBalloonData={moreBalloonData}
           accordionData={accordionContext}
           sharedMenu={sharedMenu}
         />
@@ -78,8 +204,9 @@ export default (
       <Navigation className="navigation navigation--registered navigation--sticked"
         svgUri="assets/icons.svg"
         userLoggedIn
-        sectionsCardData={navgiationLinks}
+        sectionsCardData={navigationLinks}
         accordionData={accordionContext}
+        moreBalloonData={moreBalloonData}
         sharedMenu={sharedMenu}
       />
       <p style={{ paddingBottom: '400px' }}>
@@ -91,8 +218,9 @@ export default (
         svgUri="assets/icons.svg"
         userLoggedIn
         userIsSubscriber
-        sectionsCardData={navgiationLinks}
+        sectionsCardData={navigationLinks}
         accordionData={accordionContext}
+        moreBalloonData={moreBalloonData}
         sharedMenu={sharedMenu}
       />
       <p style={{ paddingBottom: '400px' }}>

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,19 @@
-@import '@economist/component-icon';
 @import '@economist/component-balloon';
+@import '@economist/component-icon';
 @import './settings';
 @import './user-menu';
 @import './search';
 @import './mobile-menu';
 @import './main-navigation';
 @import '@economist/component-typography';
-@import '@economist/component-icon/backgrounds/headset.css';
-@import '@economist/component-icon/backgrounds/video.css';
-@import '@economist/component-icon/backgrounds/film.css';
-@import '@economist/component-icon/backgrounds/magnifier.css';
-@import '@economist/component-icon/backgrounds/user.css';
+@import '@economist/component-icon/backgrounds/apps.css';
 @import '@economist/component-icon/backgrounds/close.css';
+@import '@economist/component-icon/backgrounds/film.css';
+@import '@economist/component-icon/backgrounds/headset.css';
+@import '@economist/component-icon/backgrounds/magnifier.css';
+@import '@economist/component-icon/backgrounds/radio.css';
+@import '@economist/component-icon/backgrounds/user.css';
+@import '@economist/component-icon/backgrounds/video.css';
 
 .navigation {
   font-family: var(--fontfamily-sans);
@@ -22,10 +24,24 @@
 /* stylelint-disable */
 .navigation .navigation__main-navigation-link,
 .navigation .navigation__main-navigation-link > a {
-/* stylelint-enable */
   box-sizing: border-box;
   height: var(--navigation__default-height);
   text-decoration: none;
+}
+
+.navigation .navigation__main-navigation-link > span {
+  display: inline-block;
+  height: 100%;
+}
+/* stylelint-enable */
+
+.navigation__more .list {
+  column-count: 1;
+}
+
+.navigation__more .sections-card__list-sections,
+.navigation__more .sections-card__list-blogs {
+  max-width: 40%;
 }
 
 /* stylelint-disable */

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import Balloon from '@economist/component-balloon';
 import Button from '@economist/component-link-button';
 import GoogleSearch from '@economist/component-google-search';
 import Icon from '@economist/component-icon';
+import MenuMore from './parts/menu-more';
+import MenuTopic from './parts/menu-topic';
 import React from 'react';
 import SectionsCard from '@economist/component-sections-card';
 import StickyPosition from 'react-sticky-position';
@@ -37,6 +39,7 @@ export default class Navigation extends React.Component {
     }).isRequired,
     sectionsCardData: SectionsCard.propTypes.data,
     accordionData: Accordion.propTypes.list,
+    moreBalloonData: SectionsCard.propTypes.data,
   }
 
   static defaultProps = {
@@ -62,7 +65,7 @@ export default class Navigation extends React.Component {
     const userMenuBalloonTrigger = (
       <Button
         href={loginLogoutUrl}
-        className={`navigation__user-menu-link navigation__user-menu-link--${ buttonClassSuffix }`}
+        className={`navigation__user-menu-link navigation__link navigation__user-menu-link--${ buttonClassSuffix }`}
         icon={{ icon: 'user', color: 'thimphu', useBackground: true }}
         unstyled
       >{buttonText}</Button>
@@ -240,15 +243,11 @@ export default class Navigation extends React.Component {
   render() {
     const { searching } = this.state;
     const svgUri = { uri: this.props.svgUri } || {};
+
     const menuAccordionTrigger = (
       <a href="/Sections" className="navigation__sections-link navigation--tappable-icon">
         <Icon icon="hamburger" size="28px" color="white" />
         <Icon icon="close" size="28px" color="white" />
-      </a>
-    );
-    const menuSectionsTrigger = (
-      <a href={this.props.sharedMenu.topic.href} className="navigation__sections-link">
-        {this.props.sharedMenu.topic.title}
       </a>
     );
     const children = [ (
@@ -264,21 +263,19 @@ export default class Navigation extends React.Component {
           >
             <Accordion list={this.props.accordionData} />
           </Balloon>
-          <Balloon
-            className="navigation__main-navigation-link navigation__main-sections-card"
-            showOnHover
-            trigger={menuSectionsTrigger}
-          >
-            <div>
-              <SectionsCard data={this.props.sectionsCardData} />
-            </div>
-          </Balloon>
+          <MenuTopic
+            href={this.props.sharedMenu.topic.href}
+            sectionsCardData={this.props.sectionsCardData}
+            title={this.props.sharedMenu.topic.title}
+          />
           <a href="/printedition" className="navigation__main-navigation-link navigation__link">
             Print edition
           </a>
-          <a href={this.props.sharedMenu.more.href} className="navigation__main-navigation-link navigation__link">
-            {this.props.sharedMenu.more.title}
-          </a>
+          <MenuMore
+            moreBalloonData={this.props.moreBalloonData}
+            href={this.props.sharedMenu.more.href}
+            title={this.props.sharedMenu.more.title}
+          />
           <div className="navigation__primary-expander" />
           <Button href={this.props.sharedMenu.subscribe.href}
             className="navigation__main-navigation-link navigation__link navigation__main-navigation-link-subscribe"

--- a/src/main-navigation.css
+++ b/src/main-navigation.css
@@ -27,6 +27,9 @@
 
 .navigation__sections-link {
   position: relative;
+  height: 100%;
+  color: var(--color-thimphu);
+  text-decoration: none;
 }
 
 .navigation__main-navigation-link-subscribe {
@@ -35,6 +38,7 @@
 
 .navigation__main-navigation-link .balloon-content {
   right: 0;
+  left: 0;
 }
 
 .navigation__main-sections-card .balloon-content {

--- a/src/mobile-menu.css
+++ b/src/mobile-menu.css
@@ -1,7 +1,7 @@
 @import './settings';
 @import '@economist/component-typography';
-@import '@economist/component-accordion';
-@import '@economist/component-accordion/styles.css';
+@import '@economist/component-accordion/lib';
+@import '@economist/component-accordion/lib/styles.css';
 @import '@economist/component-icon/backgrounds/video.css';
 @import '@economist/component-icon/backgrounds/headset.css';
 @import '@economist/component-icon/backgrounds/film.css';
@@ -23,6 +23,14 @@
 
 .navigation--tappable-icon {
   padding: 0 2em;
+}
+
+.accordion__hr {
+  height: 0;
+  margin-right: 2em;
+  margin-left: 2em;
+  border: solid var(--color-london);
+  border-width: 1px 0 0;
 }
 
 /* stylelint-disable */

--- a/src/parts/menu-more.js
+++ b/src/parts/menu-more.js
@@ -1,0 +1,34 @@
+import React, { PropTypes as T } from 'react';
+import Balloon from '@economist/component-balloon';
+import SectionsCard from '@economist/component-sections-card';
+
+function MenuMore({ href, title, moreBalloonData }) {
+  return (
+    <Balloon
+      dynamicPositioning={false}
+      className="navigation__more navigation__main-navigation-link navigation__main-sections-card"
+      showOnHover
+      trigger={(
+        <a href={href} className="navigation__sections-link">
+          {title}
+        </a>
+      )}
+    >
+      <SectionsCard
+        titles={{
+          sections: 'Apps and Digital Editions',
+          blogs: 'From the economist group',
+        }}
+        data={moreBalloonData}
+      />
+    </Balloon>
+  );
+}
+
+MenuMore.propTypes = {
+  href: T.string.isRequired,
+  title: T.string.isRequired,
+  moreBalloonData: SectionsCard.propTypes.data,
+};
+
+export default MenuMore;

--- a/src/parts/menu-topic.js
+++ b/src/parts/menu-topic.js
@@ -1,0 +1,30 @@
+import Balloon from '@economist/component-balloon';
+import React from 'react';
+import SectionsCard from '@economist/component-sections-card';
+import { PropTypes as T } from 'react';
+
+function MenuTopic({ href, title, sectionsCardData }) {
+  return (
+    <Balloon
+      className="navigation__main-navigation-link navigation__main-sections-card"
+      showOnHover
+      trigger={(
+        <a href={href} className="navigation__sections-link">
+          {title}
+        </a>
+      )}
+    >
+      <div>
+        <SectionsCard data={sectionsCardData} />
+      </div>
+    </Balloon>
+  );
+}
+
+MenuTopic.propTypes = {
+  href: T.string.isRequired,
+  title: T.string.isRequired,
+  sectionsCardData: SectionsCard.propTypes.data,
+};
+
+export default MenuTopic;

--- a/src/user-menu.css
+++ b/src/user-menu.css
@@ -31,7 +31,8 @@
 }
 
 .navigation__user-menu .balloon__link,
-.navigation__user-menu-link--logout {
+.navigation__user-menu-link--logout,
+.navigation__user-menu-link--login {
   height: var(--navigation__default-height);
   white-space: nowrap;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,10 +6,10 @@ import chaiReactElement from 'chai-react-element';
 import links from './links';
 chai.use(chaiReactElement).should();
 // Get data.
-import navgiationLinks from '@economist/component-sections-card/context';
+import navigationLinks from '@economist/component-sections-card/lib/context';
 /* eslint-disable id-match */
 // Force media links to use icon as background.
-navgiationLinks.media.forEach((mediaLink) => {
+navigationLinks.media.forEach((mediaLink) => {
   mediaLink.icon = {
     useBackground: true,
     color: 'chicago',


### PR DESCRIPTION
live @ http://gcedo.github.io/component-navigation/ (some icons return a 404 on `gh-pages`, you may want to clone it locally)

BREAKING CHANGE

- The following dependencies were updated:
    - component-sections-card, needed support for custom sections titles
    - component-accordion, needed to display a horizontal rule
    - component-icon, needed the radio icon
- The 'More' navbar link is now a Balloon component, which displays a SectionsCard component with links divided into three sections:
    - Apps and digital editions
    - Media
    - From the economist group
- The Media section now features also 'Radio' and 'Apps'
- The mobile menu was changed as follows:
    - Print Edition is moved right before the Media icons
    - Apps and Radio are added to the Media icons
    - Products is added right after the Media icons, displaying the links from the More SectionsCard